### PR TITLE
Use `he` for HTML entity escaping

### DIFF
--- a/lib/connect-oembed.js
+++ b/lib/connect-oembed.js
@@ -1,14 +1,14 @@
-var ent = require('ent'),
+var he = require('he'),
     url = require('url');
-    
+
 module.exports = function(config, cb) {
   if (typeof config == "function") {
     cb = config;
     config = {};
   }
-    
+
   config = config || {};
-  
+
   var respondJson = function(req, res, next, options) {
     var output = JSON.stringify(options);
     var callback = req.oembed.callback || req.oembed.jsonp;
@@ -30,11 +30,11 @@ module.exports = function(config, cb) {
       res.end(output);
     }
   }
-  
+
   var respondXml = function(req, res, next, options) {
     if (options.html)
-      options.html = ent.encode(html);
-      
+      options.html = he.escape(html);
+
     var output = '<?xml version="1.0" encoding="utf-8" standalone="yes"?>';
     output += '<oembed>';
     for (var key in options) {
@@ -46,7 +46,7 @@ module.exports = function(config, cb) {
       }
     }
     output += '</oembed>';
-    
+
     var headers = {
       'Content-type': 'text/xml',
       'Content-length': output.length
@@ -54,36 +54,36 @@ module.exports = function(config, cb) {
     res.writeHead(200, headers);
     res.end(output);
   }
-  
+
   var respond = function(req, res, next, options) {
     var format = req.oembed.format;
-    
+
     if (format == "json")
       respondJson(req, res, next, options);
-    else if (format == "xml") 
+    else if (format == "xml")
       respondXml(req, res, next, options);
     else
       next(); // format is invalid (should never get here)
   }
-  
+
   return function(req, res, next) {
     var oembedQuery = url.parse(req.url, true /*parse query*/).query;
     oembedQuery.format = oembedQuery.format || "json";
-    
+
     if (oembedQuery.format != "json" && oembedQuery.format != "xml") {
       res.writeHead(501);
       res.end();
       return;
     }
-    
+
     if (!oembedQuery.url) {
       next(); // trickle down to 404
       return;
     }
-    
+
     req.oembed = oembedQuery;
     res.oembed = {};
-    
+
     // make helpers
     res.oembed.photo = function(url, width, height, options) {
       options = options || {};
@@ -93,7 +93,7 @@ module.exports = function(config, cb) {
       options.height = height;
       respond(req, res, next, options);
     }
-    
+
     res.oembed.video = function(html, width, height, options) {
       options = options || {};
       options.type = "video";
@@ -102,13 +102,13 @@ module.exports = function(config, cb) {
       options.height = height;
       respond(req, res, next, options);
     }
-    
+
     res.oembed.link = function(options) {
       options = options || {};
       options.type = "link";
       respond(req, res, next, options);
     }
-    
+
     res.oembed.rich = function(html, width, height, options) {
       options = options || {};
       options.type = "rich";
@@ -117,7 +117,7 @@ module.exports = function(config, cb) {
       options.height = height;
       respond(req, res, next, options);
     }
-    
+
     cb(req, res, next);
   };
 

--- a/package.json
+++ b/package.json
@@ -3,19 +3,19 @@
   "description": "oEmbed provider middleware for Node.js Connect and Express",
   "author": "sharpfog <me@sharpfog.com>",
   "version": "0.0.1",
-  "license" : "MIT",
+  "license": "MIT",
   "dependencies": {
     "connect": "2.6.x",
-    "ent": "0.0.4"
+    "he": "~0.1.1"
   },
   "devDependencies": {
-    "nodeunit" : "0.7.x"
+    "nodeunit": "0.7.x"
   },
   "engine": "node >= 0.6.6",
-  "main" : "index",
-  "repository" : {
-    "type" : "git",
-    "url" : "http://github.com/sharpfog/connect-oembed.git"
+  "main": "index",
+  "repository": {
+    "type": "git",
+    "url": "http://github.com/sharpfog/connect-oembed.git"
   },
   "scripts": {
     "test": "nodeunit test"


### PR DESCRIPTION
[_he_](http://mths.be/he) is a drop-in replacement for `ent`. `he` has an `escape` method that is more efficient than using `encode` for the use case of connect-oembed.

This patch replaces `ent` with `he`.
